### PR TITLE
lock the 'parcel-bundler' to v1.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typescript": "^2.9.2"
   },
   "dependencies": {
-    "parcel-bundler": "^1.9.7",
+    "parcel-bundler": "1.9.7",
     "reflect-metadata": "^0.1.12",
     "superfine": "^6.0.1"
   }


### PR DESCRIPTION
because 'parcel-plugin-typescript' can't support 'parcel-bundler' v1.10.x